### PR TITLE
Fix setDate before setMonth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.1 (04.04.2023)
+
+Fixed `getStartOfMonth` which returned wrong value when the second argument is passed 
+and the difference between the current and the desired month is not equal to 0.
+
+
 ## 5.0.0 (27.01.2023)
 
 Added alternative functions to deal with both full and calendar days, months, years.

--- a/lib/getStartOfMonth.ts
+++ b/lib/getStartOfMonth.ts
@@ -9,11 +9,12 @@ import { ChronosDate, ensureDate } from './helpers/ensureDate';
 export default (value: ChronosDate, diff = 0): Date => {
   const date = ensureDate(value);
 
+  date.setDate(1);
+
   if (diff) {
     date.setMonth(date.getMonth() + diff);
   }
 
-  date.setDate(1);
   date.setHours(0, 0, 0, 0);
 
   return date;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/chronos",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/chronos",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "One library to rule the time",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -527,6 +527,10 @@ describe('getStartOfMinutes, getStartOfHours, getStartOfDay, getStartOfWeek, get
     expect(getStartOfMonth(new Date(2020, 2, 2, 23, 59), -1)).to.equalTime(new Date(2020, 1, 1, 0, 0));
   });
 
+  it('returns date of start of month - 1', () => {
+    expect(getStartOfMonth(new Date(2023, 2, 31, 23, 59), -1)).to.equalTime(new Date(2023, 1, 1, 0, 0));
+  });
+
   it('returns date of start of year', () => {
     expect(getStartOfYear(new Date(2020, 1, 1, 23, 59))).to.equalTime(new Date(2020, 0, 1, 0, 0));
   });


### PR DESCRIPTION
По-русски.

Получение первого числа предыдущего месяца используя метод `getStartOfMonth` с передачей параметра `-1` возвращает ошибку если в предыдущем месяце было меньше дней, чем в текущем.
Например, в марте 31 день, в феврале 28, при попытке сменить месяц на предыдущий через `setMonth` происходит пересчёт дней: 31-28 = 3 дня, которые прибавляются к дате после смены месяца, в итоге получается 3 марта.
Предварительная установка 1 числа до смены месяца (`setDate(1)`) исправляет ситуацию.

Та же ситуация при получении разницы между датами методом `getRelativeDate` (на данный момент тест падает), при выполнении смены месяца `date.setMonth(date.getMonth() - 1)` когда текущая дата 31 марта в результате получается дата 3 марта и метод `getRelativeDate` возвращает разницу в месяцах равную 0.

Я не стал исправлять этот тест, мне кажется там немного сложнее ситуация, когда нужно получить не количество дней, а именно "месяц", а он зависит от количества дней между датами (30, 31; формально между 31 марта и 28 февраля будет месяц)